### PR TITLE
Fix for ingress reinstalls

### DIFF
--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
                         writeFile file: 'ing-values.yaml', text: ingValue
-                        sh 'helm install --wait --name jxing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml||true'
+                        sh 'helm install --replace --wait --name jxing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml||true'
                     }
                 }
             }


### PR DESCRIPTION
This is necessary when we reinstall jenkins-x ingress on the same cluster.