### PR TITLE
 Automate DNS wildcard alias creation for jenkins-x

### DIFF
--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -59,22 +59,6 @@ def jxValueMap = [
         ]
 ]
 
-def r53WildcardRecord = [
-    Comment: "Creating Alias resource record sets in Route 53",
-    Changes: [{
-        Action: "UPSERT",
-            ResourceRecordSet: [
-                Name: "",
-                Type: "A",
-                AliasTarget: [
-                    HostedZoneId: "",
-                    DNSName: "",
-                    EvaluateTargetHealth: false
-                ]
-        ]
-    }]
-]
-
 def converterPy = '''
 import yaml
 import io
@@ -130,19 +114,32 @@ pipeline {
                             println "Getting domain name"
                             def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
                                                    returnStdout: true).trim()
-                            r53WildcardRecord.Changes.ResourceRecordSet.Name = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
+                            r53WildcardRecordName = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
 
                             println "Getting ingress NLB information"
                             ingressNLBAddress = sh(script: "kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'",
                                                    returnStdout: true).trim()
                             ingressNLBHostedZoneID = sh(script: "aws --region \$AWS_REGION elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text",
                                                    returnStdout: true).trim()
-                            r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.HostedZoneId = ingressNLBHostedZoneID
-                            r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.DNSName = ingressNLBAddress
 
                             println "Generating record for DNS update"
-                            def r53WildcardRecordJSON = JsonOutput.toJson(r53WildcardRecord)
-                            r53WildcardRecordJSON = JsonOutput.prettyPrint(r53WildcardRecordJSON)
+                            def r53WildcardRecordJSON = """
+                            {
+                                "Comment": "Creating Alias resource record sets in Route 53",
+                                "Changes": [{
+                                    "Action": "UPSERT",
+                                    "ResourceRecordSet": {
+                                        "Name": "${r53WildcardRecordName}",
+                                        "Type": "A",
+                                        "AliasTarget": {
+                                            "HostedZoneId": "${ingressNLBHostedZoneID}",
+                                            "DNSName": "${ingressNLBAddress}",
+                                            "EvaluateTargetHealth": false
+                                        }
+                                    }
+                                }]
+                            }
+                            """
                             writeFile file: 'jx_r53_alias.json', text: r53WildcardRecordJSON
                             sh "cat jx_r53_alias.json"
 

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -61,7 +61,7 @@ def jxValueMap = [
 
 def r53WildcardRecord = [
     Comment: "Creating Alias resource record sets in Route 53",
-    Changes: [[
+    Changes: [{
         Action: "UPSERT",
             ResourceRecordSet: [
                 Name: "",
@@ -72,7 +72,7 @@ def r53WildcardRecord = [
                     EvaluateTargetHealth: false
                 ]
         ]
-    ]]
+    }]
 ]
 
 def converterPy = '''

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
 
                             ingressNLBAddress = sh(script: " kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname' ",
                                                    returnStdout: true).trim()
-                            ingressNLBHostedZoneID = sh(script: " aws elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text ",
+                            ingressNLBHostedZoneID = sh(script: " aws --region \$AWS_REGION elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text ",
                                                    returnStdout: true).trim()
                             r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.HostedZoneId = ingressNLBHostedZoneID
                             r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.DNSName = ingressNLBAddress

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -61,7 +61,7 @@ def jxValueMap = [
 
 def r53WildcardRecord = [
     Comment: "Creating Alias resource record sets in Route 53",
-    Changes: [
+    Changes: [[
         Action: "UPSERT",
             ResourceRecordSet: [
                 Name: "",
@@ -72,7 +72,7 @@ def r53WildcardRecord = [
                     EvaluateTargetHealth: false
                 ]
         ]
-    ]
+    ]]
 ]
 
 def converterPy = '''

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -66,7 +66,7 @@ def r53WildcardRecord = [
                 Type: "A",
                 AliasTarget: [
                     HostedZoneId: "",
-                    DNSName: ""
+                    DNSName: "",
                     EvaluateTargetHealth: false
                 ]
         ]

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -141,9 +141,9 @@ pipeline {
                                                    returnStdout: true).trim()
                             r53WildcardRecord.Changes.ResourceRecordSet.Name = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
 
-                            ingressNLBHostedZoneID = sh(script: " aws elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text ",
-                                                   returnStdout: true).trim()
                             ingressNLBAddress = sh(script: " kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname' ",
+                                                   returnStdout: true).trim()
+                            ingressNLBHostedZoneID = sh(script: " aws elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text ",
                                                    returnStdout: true).trim()
                             r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.HostedZoneId = ingressNLBHostedZoneID
                             r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.DNSName = ingressNLBAddress

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -57,6 +57,22 @@ def jxValueMap = [
         ]
 ]
 
+def r53WildcardRecord = [
+    Comment: "Creating Alias resource record sets in Route 53",
+    Changes: [
+        Action: "UPSERT",
+            ResourceRecordSet: [
+                Name: "",
+                Type: "A",
+                AliasTarget: [
+                    HostedZoneId: "",
+                    DNSName: ""
+                    EvaluateTargetHealth: false
+                ]
+        ]
+    ]
+]
+
 def converterPy = '''
 import yaml
 import io
@@ -114,9 +130,30 @@ pipeline {
                 }
             }
         }
-        stage('Manual create domain') {
+        stage('Create wildcard DNS record') {
             steps {
-                input message: "Create an domain defained for jx installation in Route53. Should we continue?", ok: "Yes, we should."
+                dir("operations/$AWS_REGION/env") {
+                    withProxyEnv() {
+                        script {
+                            def parameters = readYaml file: 'jenkins/parameters.yaml'
+
+                            def r53DomainName = sh(script: " aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name' ", 
+                                                   returnStdout: true).trim()
+                            r53WildcardRecord.Changes.ResourceRecordSet.Name = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
+
+                            ingressNLBHostedZoneID = sh(script: " aws elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text ",
+                                                   returnStdout: true).trim()
+                            ingressNLBAddress = sh(script: " kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname' ",
+                                                   returnStdout: true).trim()
+                            r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.HostedZoneId = ingressNLBHostedZoneID
+                            r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.DNSName = ingressNLBAddress
+
+                            writeJSON file: 'jx_r53_alias.json', json: r53WildcardRecord, pretty: 4
+                            
+                            sh 'cat jx_r53_alias.json'
+                        }
+                    }
+                }
             }
         }
         stage('Install jx on k8s') {

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -173,7 +173,7 @@ pipeline {
                                 sh 'python -u convert.py'
                                 // This next line is to change in file myvalues.yaml from \\n to \n and we need sed with s/\\\\/\\/g written as below due to interpolation done by groovy.
                                 sh 'sed -i "s/\\\\\\\\\\\\\\\\/\\\\\\\\/g" myvalues.yaml '
-                                sh 'jx install -b --headless --default-admin-password ' + parameters.defaultAdminPassword + ' --domain="' + r53DomainName + '" --verbose=true --provider=kubernetes --no-default-environments --git-username=' + parameters.gitUsername + ' --git-api-token ' + parameters.gitApiToken + ' --git-provider-url="' + parameters.gitProviderUrl + '"'                            }
+                                sh 'jx install -b --headless --default-admin-password ' + parameters.defaultAdminPassword + ' --domain="' + parameters.jxDomainAliasPrefix + "." + r53DomainName + '" --verbose=true --provider=kubernetes --no-default-environments --git-username=' + parameters.gitUsername + ' --git-api-token ' + parameters.gitApiToken + ' --git-provider-url="' + parameters.gitProviderUrl + '"'                            }
                         }
                     }
                 }

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -157,6 +157,11 @@ pipeline {
                         withProxyEnv() {
                             script {
                                 def parameters = readYaml file: 'jenkins/parameters.yaml'
+
+                                println "Getting domain name"
+                                def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
+                                                       returnStdout: true).trim()
+                                
                                 URI url_http_proxy = new URI(env.http_proxy)
                                 URI url_https_proxy = new URI(env.https_proxy)
                                 def jenkins_no_proxy =  env.no_proxy.toString()
@@ -168,7 +173,7 @@ pipeline {
                                 sh 'python -u convert.py'
                                 // This next line is to change in file myvalues.yaml from \\n to \n and we need sed with s/\\\\/\\/g written as below due to interpolation done by groovy.
                                 sh 'sed -i "s/\\\\\\\\\\\\\\\\/\\\\\\\\/g" myvalues.yaml '
-                                sh 'jx install -b --headless --default-admin-password ' + parameters.defaultAdminPassword + ' --domain="' + parameters.jxDomain + '" --verbose=true --provider=kubernetes --no-default-environments --git-username=' + parameters.gitUsername + ' --git-api-token ' + parameters.gitApiToken + ' --git-provider-url="' + parameters.gitProviderUrl + '"'                            }
+                                sh 'jx install -b --headless --default-admin-password ' + parameters.defaultAdminPassword + ' --domain="' + r53DomainName + '" --verbose=true --provider=kubernetes --no-default-environments --git-username=' + parameters.gitUsername + ' --git-api-token ' + parameters.gitApiToken + ' --git-provider-url="' + parameters.gitProviderUrl + '"'                            }
                         }
                     }
                 }

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -1,5 +1,7 @@
 #!groovy
 
+import groovy.json.JsonOutput
+
 def helmRbacConfig = '''
 apiVersion: v1
 kind: ServiceAccount

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -154,7 +154,8 @@ pipeline {
 
                             println "Generating record for DNS update"
                             def r53WildcardRecordJSON = JsonOutput.toJson(r53WildcardRecord)
-                            writeJSON file: 'jx_r53_alias.json', json: r53WildcardRecordJSON, pretty: 4
+                            r53WildcardRecordJSON = JsonOutput.prettyPrint(r53WildcardRecordJSON)
+                            writeFile file: 'jx_r53_alias.json', text: r53WildcardRecordJSON
                             sh "cat jx_r53_alias.json"
 
                             println "Creating/updating Route53 entry"

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
                         writeFile file: 'ing-values.yaml', text: ingValue
-                        sh 'helm install --wait --name jxing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml||true'
+                        sh 'helm install --replace --wait --name jxing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml||true'
                     }
                 }
             }

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -120,18 +120,6 @@ pipeline {
                 }
             }
         }
-        stage('Init jx tool') {
-            steps {
-                dir("operations/$AWS_REGION/env") {
-                    withProxyEnv() {
-                        script {
-                            def parameters = readYaml file: 'jenkins/parameters.yaml'
-                            sh 'jx create git server --kind bitbucketserver --name BitBucket --url ' + parameters.gitBitbucketServer + ' ||true'
-                        }
-                    }
-                }
-            }
-        }
         stage('Create wildcard DNS record') {
             steps {
                 dir("operations/$AWS_REGION/env") {
@@ -159,7 +147,7 @@ pipeline {
                             sh "cat jx_r53_alias.json"
 
                             println "Creating/updating Route53 entry"
-                            sh "echo aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://jx_r53_alias.json"
+                            sh "aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://jx_r53_alias.json"
                         }
                     }
                 }

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
 
                             println "Getting domain name"
                             def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
-                                                   returnStdout: true).trim()
+                                                   returnStdout: true).trim().replaceAll("\\.\$", "")
                             r53WildcardRecordName = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
 
                             println "Getting ingress NLB information"
@@ -160,7 +160,7 @@ pipeline {
 
                                 println "Getting domain name"
                                 def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
-                                                       returnStdout: true).trim()
+                                                       returnStdout: true).trim().replaceAll("\\.\$", "")
                                 
                                 URI url_http_proxy = new URI(env.http_proxy)
                                 URI url_https_proxy = new URI(env.https_proxy)

--- a/operations/jx/Jenkinsfile
+++ b/operations/jx/Jenkinsfile
@@ -137,20 +137,26 @@ pipeline {
                         script {
                             def parameters = readYaml file: 'jenkins/parameters.yaml'
 
-                            def r53DomainName = sh(script: " aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name' ", 
+                            println "Getting domain name"
+                            def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
                                                    returnStdout: true).trim()
                             r53WildcardRecord.Changes.ResourceRecordSet.Name = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
 
-                            ingressNLBAddress = sh(script: " kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname' ",
+                            println "Getting ingress NLB information"
+                            ingressNLBAddress = sh(script: "kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'",
                                                    returnStdout: true).trim()
-                            ingressNLBHostedZoneID = sh(script: " aws --region \$AWS_REGION elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text ",
+                            ingressNLBHostedZoneID = sh(script: "aws --region \$AWS_REGION elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text",
                                                    returnStdout: true).trim()
                             r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.HostedZoneId = ingressNLBHostedZoneID
                             r53WildcardRecord.Changes.ResourceRecordSet.AliasTarget.DNSName = ingressNLBAddress
 
-                            writeJSON file: 'jx_r53_alias.json', json: r53WildcardRecord, pretty: 4
-                            
-                            sh 'cat jx_r53_alias.json'
+                            println "Generating record for DNS update"
+                            def r53WildcardRecordJSON = JsonOutput.toJson(r53WildcardRecord)
+                            writeJSON file: 'jx_r53_alias.json', json: r53WildcardRecordJSON, pretty: 4
+                            sh "cat jx_r53_alias.json"
+
+                            println "Creating/updating Route53 entry"
+                            sh "echo aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://jx_r53_alias.json"
                         }
                     }
                 }


### PR DESCRIPTION
Automate previously manual step that will create Route53 wildcard alias to be used by all jenkins-x based applications for convenient access. Alias will automatically point to NLB exposing ingress controller.
NOTE: this feature requires new parameters in configuration repository.
See:
https://github.com/kentrikos/template-environment-configuration/pull/4
https://github.com/kentrikos/aws-bootstrap/pull/12