### PR TITLE
Fix for K8s cluster destroy

### DIFF
--- a/operations/kubernetes/destroy/Jenkinsfile
+++ b/operations/kubernetes/destroy/Jenkinsfile
@@ -60,6 +60,29 @@ pipeline {
                 }
             }
         }
+        stage('Kops check') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    ansiColor('xterm') {
+                        withProxyEnv() {
+                            sh '''#!/bin/bash -x
+                            /usr/bin/terraform apply -input=false tfplandestroy
+                            K8S_CLUSTER_NAME="${PRODUCT_DOMAIN_NAME}-${ENVIRONMENT_TYPE}-ops.k8s.local"
+                            KOPS_STATE_BUCKET="kops-${AWS_OPERATIONS_ACCOUNT_NUMBER}-${AWS_REGION}-${PRODUCT_DOMAIN_NAME}-${ENVIRONMENT_TYPE}-ops"
+                            if kops --state s3://${KOPS_STATE_BUCKET} get cluster ${K8S_CLUSTER_NAME};
+                            then
+                              echo "Seems that Terraform has not destroyed the cluster, perhaps it was not fully deployed and marked as tainted resource."
+                              echo "Deleting directly with kops..."
+                              kops --state s3://${KOPS_STATE_BUCKET} delete cluster ${K8S_CLUSTER_NAME} --yes
+                            else
+                              echo "Looks like the cluster has beed finally destroyed."
+                            fi
+                            '''
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 void withProxyEnv(List envVars = [],  def body) {

--- a/operations/kubernetes/destroy/Jenkinsfile
+++ b/operations/kubernetes/destroy/Jenkinsfile
@@ -44,17 +44,7 @@ pipeline {
                 dir("operations/$AWS_REGION/env") {
                     ansiColor('xterm') {
                         withProxyEnv() {
-                            sh '''#!/bin/bash -x
-                            /usr/bin/terraform apply -input=false tfplandestroy
-                            K8S_CLUSTER_NAME="${PRODUCT_DOMAIN_NAME}-${ENVIRONMENT_TYPE}-ops.k8s.local"
-                            KOPS_STATE_BUCKET="kops-${AWS_OPERATIONS_ACCOUNT_NUMBER}-${AWS_REGION}-${PRODUCT_DOMAIN_NAME}-${ENVIRONMENT_TYPE}-ops"
-                            kops --state s3://${KOPS_STATE_BUCKET} get cluster ${K8S_CLUSTER_NAME} && \
-                              (
-                                echo "Seems that Terraform has not destroyed the cluster, perhaps it was not fully deployed and marked as tainted resource."; \
-                                echo "Deleting directly with kops..."; \
-                                kops --state s3://${KOPS_STATE_BUCKET} delete cluster ${K8S_CLUSTER_NAME} --yes
-                              )
-                            '''
+                            sh '/usr/bin/terraform apply -input=false tfplandestroy'
                         }
                     }
                 }

--- a/operations/kubernetes/destroy/Jenkinsfile
+++ b/operations/kubernetes/destroy/Jenkinsfile
@@ -56,7 +56,6 @@ pipeline {
                     ansiColor('xterm') {
                         withProxyEnv() {
                             sh '''#!/bin/bash -x
-                            /usr/bin/terraform apply -input=false tfplandestroy
                             K8S_CLUSTER_NAME="${PRODUCT_DOMAIN_NAME}-${ENVIRONMENT_TYPE}-ops.k8s.local"
                             KOPS_STATE_BUCKET="kops-${AWS_OPERATIONS_ACCOUNT_NUMBER}-${AWS_REGION}-${PRODUCT_DOMAIN_NAME}-${ENVIRONMENT_TYPE}-ops"
                             if kops --state s3://${KOPS_STATE_BUCKET} get cluster ${K8S_CLUSTER_NAME};

--- a/operations/kubernetes/destroy/Jenkinsfile
+++ b/operations/kubernetes/destroy/Jenkinsfile
@@ -44,7 +44,17 @@ pipeline {
                 dir("operations/$AWS_REGION/env") {
                     ansiColor('xterm') {
                         withProxyEnv() {
-                            sh '/usr/bin/terraform apply -input=false tfplandestroy'
+                            sh '''#!/bin/bash -x
+                            /usr/bin/terraform apply -input=false tfplandestroy
+                            K8S_CLUSTER_NAME="${PRODUCT_DOMAIN_NAME}-${ENVIRONMENT_TYPE}-ops.k8s.local"
+                            KOPS_STATE_BUCKET="kops-${AWS_OPERATIONS_ACCOUNT_NUMBER}-${AWS_REGION}-${PRODUCT_DOMAIN_NAME}-${ENVIRONMENT_TYPE}-ops"
+                            kops --state s3://${KOPS_STATE_BUCKET} get cluster ${K8S_CLUSTER_NAME} && \
+                              (
+                                echo "Seems that Terraform has not destroyed the cluster, perhaps it was not fully deployed and marked as tainted resource."; \
+                                echo "Deleting directly with kops..."; \
+                                kops --state s3://${KOPS_STATE_BUCKET} delete cluster ${K8S_CLUSTER_NAME} --yes
+                              )
+                            '''
                         }
                     }
                 }


### PR DESCRIPTION
This is workaround for situation, when we attempt to destroy a cluster that was not fully deployed (e.g. Jenkins job interrupted) and remains in unstable state. Terraform will mark it as tainted resource and it seems that 'when = "destroy''' null_resource/local-exec provisioners are not run when tainted resources are deleted.
Possibly similar issue: https://github.com/hashicorp/terraform/issues/13549#issuecomment-294254116