### PR TITLE
Updated and new Grafana/Prometheus Jenkins jobs

### DIFF
--- a/application/prometheus/destroy/Jenkinsfile
+++ b/application/prometheus/destroy/Jenkinsfile
@@ -1,0 +1,84 @@
+#!groovy
+
+pipeline {
+
+    agent any
+
+    parameters {
+        choice(name: 'K8S_FLAVOR', choices: ["eks", "kops"],
+               description: 'Choose type of Kubernetes cluster (required for kops)')
+    }
+
+    stages {
+        stage('Git local config') {
+            steps {
+                sh 'git config --global --add user.name "example"'
+                sh 'git config --global --add user.email "example@example.com"'
+            }
+        }
+        stage('Git clone') {
+            steps {
+                cleanWs()
+                git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
+            }
+        }
+
+        stage('Get K8s cluster flavor') {
+            steps {
+                script {
+                    if (env.K8S_FLAVOR == "eks") {
+                      K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_APPLICATION_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-app"
+                    } else {
+                      K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-app.k8s.local"
+                    }
+                    println K8S_CLUSTER_NAME
+                }
+            }
+        }
+
+        stage('Switch kubectl context to app') {
+            steps {
+                dir("application/$AWS_REGION/env-$K8S_FLAVOR") {
+                    script {
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME"
+                    }
+                }
+            }
+        }
+
+        stage('Destroy Prometheus/application') {
+            steps {
+                dir("application/$AWS_REGION/env-$K8S_FLAVOR") {
+                    withProxyEnv() {
+                        script {
+                            sh 'helm delete --purge prometheus-app'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void withProxyEnv(List envVars = [], def body) {
+    List proxies = []
+    List envVaraibles = ['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']
+    withAWSParameterStore(credentialsId: '', namePrefixes: '', naming: 'relative', path: "/$PRODUCT_DOMAIN_NAME/$ENVIRONMENT_TYPE", recursive: true, regionName: "$AWS_REGION") {
+        script {
+            if (env.PROXY_HTTP) {
+                proxies << "http_proxy=$PROXY_HTTP"
+            }
+            if (env.PROXY_HTTPS) {
+                proxies << "https_proxy=$PROXY_HTTPS"
+            }
+            if (env.PROXY_NO) {
+                proxies << "no_proxy=$PROXY_NO"
+            }
+            envVaraibles.addAll(proxies)
+        }
+    }
+    envVaraibles.addAll(envVars)
+    withEnv(envVaraibles) {
+        body.call()
+    }
+}

--- a/application/prometheus/install/Jenkinsfile
+++ b/application/prometheus/install/Jenkinsfile
@@ -1,0 +1,108 @@
+#!groovy
+
+pipeline {
+
+    agent any
+
+    parameters {
+        choice(name: 'K8S_FLAVOR', choices: ["eks", "kops"],
+               description: 'Choose type of Kubernetes cluster (required for kops)')
+    }
+
+    stages {
+        stage('Git local config') {
+            steps {
+                sh 'git config --global --add user.name "example"'
+                sh 'git config --global --add user.email "example@example.com"'
+            }
+        }
+        stage('Git clone') {
+            steps {
+                cleanWs()
+                git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
+            }
+        }
+
+        stage('Get K8s cluster flavor') {
+            steps {
+                script {
+                    if (env.K8S_FLAVOR == "eks") {
+                      K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_APPLICATION_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-app"
+                    } else {
+                      K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-app.k8s.local"
+                    }
+                    println K8S_CLUSTER_NAME
+                }
+            }
+        }
+
+        stage('Switch kubectl context to app') {
+            steps {
+                dir("application/$AWS_REGION/env-$K8S_FLAVOR") {
+                    script {
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME"
+                    }
+                }
+            }
+        }
+
+        stage('Check/create LMA namespace') {
+            steps {
+                dir("application/$AWS_REGION/env-$K8S_FLAVOR") {
+                    script {
+                        sh '''
+                        #!/bin/bash -x
+                        if ! kubectl get namespace lma;
+                        then 
+                            echo "Namespace for LMA does not exist, creating..."
+                            kubectl create namespace lma
+                        fi
+                        '''
+                    }
+                }
+            }
+        }
+
+        stage('Deploy Prometheus/application') {
+            steps {
+                dir("application/$AWS_REGION/env-$K8S_FLAVOR") {
+                    withProxyEnv() {
+                        script {
+                            /*
+                             * FIXME: ingress should be used (to be implemented after deciding how to handle R53 domains in app account)
+                             */
+                            sh """
+                            #!/bin/bash
+                            helm install --replace --wait --name prometheus-app --namespace lma stable/prometheus \
+                            --set=server.service.type:LoadBalancer,annotations:service.beta.kubernetes.io/aws-load-balancer-internal:0.0.0.0/0
+                            """
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void withProxyEnv(List envVars = [], def body) {
+    List proxies = []
+    List envVaraibles = ['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']
+    withAWSParameterStore(credentialsId: '', namePrefixes: '', naming: 'relative', path: "/$PRODUCT_DOMAIN_NAME/$ENVIRONMENT_TYPE", recursive: true, regionName: "$AWS_REGION") {
+        script {
+            if (env.PROXY_HTTP) {
+                proxies << "http_proxy=$PROXY_HTTP"
+            }
+            if (env.PROXY_HTTPS) {
+                proxies << "https_proxy=$PROXY_HTTPS"
+            }
+            if (env.PROXY_NO) {
+                proxies << "no_proxy=$PROXY_NO"
+            }
+            envVaraibles.addAll(proxies)
+        }
+    }
+    envVaraibles.addAll(envVars)
+    withEnv(envVaraibles) {
+        body.call()
+    }
+}

--- a/operations/grafana/destroy/Jenkinsfile
+++ b/operations/grafana/destroy/Jenkinsfile
@@ -32,7 +32,6 @@ pipeline {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
                         script {
-                            def parameters = readYaml file: 'grafana/parameters.yaml'
                             sh "helm delete --purge grafana"
                         }
                     }

--- a/operations/grafana/destroy/Jenkinsfile
+++ b/operations/grafana/destroy/Jenkinsfile
@@ -16,6 +16,17 @@ pipeline {
                 git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
             }
         }
+
+        stage('Switch kubectl context to ops') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    script {
+                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                }
+            }
+        }
+
         stage('Destroy Grafana') {
             steps {
                 dir("operations/$AWS_REGION/env") {

--- a/operations/grafana/destroy/Jenkinsfile
+++ b/operations/grafana/destroy/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
 
         stage('Switch kubectl context to ops') {
             steps {
-                dir("operations/$AWS_REGION/env-$env.K8S_FLAVOR") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     script {
                       sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
@@ -48,7 +48,7 @@ pipeline {
 
         stage('Destroy Grafana') {
             steps {
-                dir("operations/$AWS_REGION/env-$env.K8S_FLAVOR") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             sh "helm delete --purge grafana"

--- a/operations/grafana/destroy/Jenkinsfile
+++ b/operations/grafana/destroy/Jenkinsfile
@@ -3,6 +3,12 @@
 pipeline {
 
     agent any
+
+    parameters {
+        choice(name: 'K8S_FLAVOR', choices: ["eks", "kops"],
+               description: 'Choose type of Kubernetes cluster (required for kops)')
+    }
+
     stages {
         stage('Git local config') {
             steps {
@@ -17,11 +23,24 @@ pipeline {
             }
         }
 
+        stage('Get K8s cluster flavor') {
+            steps {
+                script {
+                    if (env.K8S_FLAVOR == "eks") {
+                      K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
+                    } else {
+                      K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                    println K8S_CLUSTER_NAME
+                }
+            }
+        }
+
         stage('Switch kubectl context to ops') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$env.K8S_FLAVOR") {
                     script {
-                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
                 }
             }
@@ -29,7 +48,7 @@ pipeline {
 
         stage('Destroy Grafana') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$env.K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             sh "helm delete --purge grafana"

--- a/operations/grafana/destroy/Jenkinsfile
+++ b/operations/grafana/destroy/Jenkinsfile
@@ -22,8 +22,7 @@ pipeline {
                     withProxyEnv() {
                         script {
                             def parameters = readYaml file: 'grafana/parameters.yaml'
-
-                            sh "jx delete addon grafana"
+                            sh "helm delete --purge grafana"
                         }
                     }
                 }

--- a/operations/grafana/install/Jenkinsfile
+++ b/operations/grafana/install/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
 
                             sh """
                             #!/bin/bash
-                            helm install --replace --wait --name grafana --namespace kube-system stable/grafana \
+                            helm install --replace --wait --name grafana --namespace lma stable/grafana \
                             --set=ingress.enabled=true,ingress.hosts={$grafana_address},adminPassword=$grafana_parameters.defaultAdminPassword
                             """
                         }

--- a/operations/grafana/install/Jenkinsfile
+++ b/operations/grafana/install/Jenkinsfile
@@ -49,9 +49,8 @@ pipeline {
 
                             sh """
                             #!/bin/bash
-                            helm install --replace --wait --name grafana --namespace kube-system stable/grafana --set=\
-                            ingress.enabled=true,ingress.hosts={grafana.$grafana_address},\
-                            adminPassword=$grafana_parameters.defaultAdminPassword
+                            helm install --replace --wait --name grafana --namespace kube-system stable/grafana \
+                            --set=ingress.enabled=true,ingress.hosts={grafana.$grafana_address},adminPassword=$grafana_parameters.defaultAdminPassword
                             """
                         }
                     }

--- a/operations/grafana/install/Jenkinsfile
+++ b/operations/grafana/install/Jenkinsfile
@@ -3,6 +3,12 @@
 pipeline {
 
     agent any
+
+    parameters {
+        choice(name: 'K8S_FLAVOR', choices: ["eks", "kops"],
+               description: 'Choose type of Kubernetes cluster (required for kops)')
+    }
+
     stages {
         stage('Git local config') {
             steps {
@@ -17,11 +23,24 @@ pipeline {
             }
         }
 
+        stage('Get K8s cluster flavor') {
+            steps {
+                script {
+                    if (env.K8S_FLAVOR == "eks") {
+                      K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
+                    } else {
+                      K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                    println K8S_CLUSTER_NAME
+                }
+            }
+        }
+
         stage('Switch kubectl context to ops') {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     script {
-                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
                 }
             }
@@ -29,7 +48,7 @@ pipeline {
 
         stage('Check/create LMA namespace') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$env.K8S_FLAVOR") {
                     script {
                         sh '''
                         #!/bin/bash -x
@@ -46,7 +65,7 @@ pipeline {
 
         stage('Deploy Grafana') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$env.K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             def grafana_parameters = readYaml file: 'grafana/parameters.yaml'

--- a/operations/grafana/install/Jenkinsfile
+++ b/operations/grafana/install/Jenkinsfile
@@ -17,6 +17,16 @@ pipeline {
             }
         }
 
+        stage('Switch kubectl context to ops') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    script {
+                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                }
+            }
+        }
+
         stage('Check/create LMA namespace') {
             steps {
                 dir("operations/$AWS_REGION/env") {

--- a/operations/grafana/install/Jenkinsfile
+++ b/operations/grafana/install/Jenkinsfile
@@ -45,12 +45,12 @@ pipeline {
                             println "Getting domain name"
                             def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + jenkins_parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
                                                    returnStdout: true).trim().replaceAll("\\.\$", "")
-                            def grafana_address = "grafana" + jenkins_parameters.jxDomainAliasPrefix + "." + r53DomainName
+                            def grafana_address = "grafana." + jenkins_parameters.jxDomainAliasPrefix + "." + r53DomainName
 
                             sh """
                             #!/bin/bash
                             helm install --replace --wait --name grafana --namespace kube-system stable/grafana \
-                            --set=ingress.enabled=true,ingress.hosts={grafana.$grafana_address},adminPassword=$grafana_parameters.defaultAdminPassword
+                            --set=ingress.enabled=true,ingress.hosts={$grafana_address},adminPassword=$grafana_parameters.defaultAdminPassword
                             """
                         }
                     }

--- a/operations/grafana/install/Jenkinsfile
+++ b/operations/grafana/install/Jenkinsfile
@@ -20,8 +20,7 @@ pipeline {
         stage('Check/create LMA namespace') {
             steps {
                 dir("operations/$AWS_REGION/env") {
-                    withProxyEnv() {
-                      script {
+                    script {
                         sh '''
                         #!/bin/bash -x
                         if ! kubectl get namespace lma;
@@ -30,7 +29,6 @@ pipeline {
                             kubectl create namespace lma
                         fi
                         '''
-                      }
                     }
                 }
             }
@@ -40,24 +38,24 @@ pipeline {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
-                      script {
-                          def grafana_parameters = readYaml file: 'grafana/parameters.yaml'
-                          def jenkins_parameters = readYaml file: 'jenkins/parameters.yaml'
+                        script {
+                            def grafana_parameters = readYaml file: 'grafana/parameters.yaml'
+                            def jenkins_parameters = readYaml file: 'jenkins/parameters.yaml'
 
-                          println "Getting domain name"
-                          def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + jenkins_parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
-                                                 returnStdout: true).trim().replaceAll("\\.\$", "")
-                          def grafana_address = "grafana" + jenkins_parameters.jxDomainAliasPrefix + "." + r53DomainName
+                            println "Getting domain name"
+                            def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + jenkins_parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
+                                                   returnStdout: true).trim().replaceAll("\\.\$", "")
+                            def grafana_address = "grafana" + jenkins_parameters.jxDomainAliasPrefix + "." + r53DomainName
 
-                          sh """
-                          #!/bin/bash
-                          helm install --replace --wait --name grafana --namespace kube-system stable/grafana --set=\
-                          ingress.enabled=true,ingress.hosts={grafana.$grafana_address},\
-                          adminPassword=$grafana_parameters.defaultAdminPassword \
-                           || true
-                          """
-                      }
+                            sh """
+                            #!/bin/bash
+                            helm install --replace --wait --name grafana --namespace kube-system stable/grafana --set=\
+                            ingress.enabled=true,ingress.hosts={grafana.$grafana_address},\
+                            adminPassword=$grafana_parameters.defaultAdminPassword
+                            """
+                        }
                     }
+                }
             }
         }
     }

--- a/operations/grafana/install/Jenkinsfile
+++ b/operations/grafana/install/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
 
         stage('Switch kubectl context to ops') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     script {
                       sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
@@ -48,7 +48,7 @@ pipeline {
 
         stage('Check/create LMA namespace') {
             steps {
-                dir("operations/$AWS_REGION/env-$env.K8S_FLAVOR") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     script {
                         sh '''
                         #!/bin/bash -x
@@ -65,7 +65,7 @@ pipeline {
 
         stage('Deploy Grafana') {
             steps {
-                dir("operations/$AWS_REGION/env-$env.K8S_FLAVOR") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             def grafana_parameters = readYaml file: 'grafana/parameters.yaml'

--- a/operations/grafana/install/Jenkinsfile
+++ b/operations/grafana/install/Jenkinsfile
@@ -16,17 +16,48 @@ pipeline {
                 git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
             }
         }
+
+        stage('Check/create LMA namespace') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    withProxyEnv() {
+                      script {
+                        sh '''
+                        #!/bin/bash -x
+                        if ! kubectl get namespace lma;
+                        then 
+                            echo "Namespace for LMA does not exist, creating..."
+                            kubectl create namespace lma
+                        fi
+                        '''
+                      }
+                    }
+                }
+            }
+        }
+
         stage('Deploy Grafana') {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
-                        script {
-                            def parameters = readYaml file: 'grafana/parameters.yaml'
+                      script {
+                          def grafana_parameters = readYaml file: 'grafana/parameters.yaml'
+                          def jenkins_parameters = readYaml file: 'jenkins/parameters.yaml'
 
-                            sh "jx create addon grafana --set adminPassword=" + parameters.defaultAdminPassword
-                        }
+                          println "Getting domain name"
+                          def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + jenkins_parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
+                                                 returnStdout: true).trim().replaceAll("\\.\$", "")
+                          def grafana_address = "grafana" + jenkins_parameters.jxDomainAliasPrefix + "." + r53DomainName
+
+                          sh """
+                          #!/bin/bash
+                          helm install --replace --wait --name grafana --namespace kube-system stable/grafana --set=\
+                          ingress.enabled=true,ingress.hosts={grafana.$grafana_address},\
+                          adminPassword=$grafana_parameters.defaultAdminPassword \
+                           || true
+                          """
+                      }
                     }
-                }
             }
         }
     }

--- a/operations/ingress/destroy/Jenkinsfile
+++ b/operations/ingress/destroy/Jenkinsfile
@@ -1,0 +1,101 @@
+#!groovy
+
+import groovy.json.JsonOutput
+
+pipeline {
+
+    agent any
+    stages {
+        stage('Git local config') {
+            steps {
+                sh 'git config --global --add user.name "example"'
+                sh 'git config --global --add user.email "example@example.com"'
+            }
+        }
+        stage('Git clone') {
+            steps {
+                cleanWs()
+                git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
+            }
+        }
+        stage('Remove wildcard DNS record') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    withProxyEnv() {
+                        script {
+                            def parameters = readYaml file: 'jenkins/parameters.yaml'
+
+                            println "Getting domain name"
+                            def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
+                                                   returnStdout: true).trim().replaceAll("\\.\$", "")
+                            r53WildcardRecordName = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
+
+                            println "Getting ingress NLB information"
+                            ingressNLBAddress = sh(script: "kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'",
+                                                   returnStdout: true).trim()
+                            ingressNLBHostedZoneID = sh(script: "aws --region \$AWS_REGION elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text",
+                                                   returnStdout: true).trim()
+
+                            println "Generating record for DNS update"
+                            def r53WildcardRecordJSON = """
+                            {
+                                "Comment": "Creating Alias resource record sets in Route 53",
+                                "Changes": [{
+                                    "Action": "DELETE",
+                                    "ResourceRecordSet": {
+                                        "Name": "${r53WildcardRecordName}",
+                                        "Type": "A",
+                                        "AliasTarget": {
+                                            "HostedZoneId": "${ingressNLBHostedZoneID}",
+                                            "DNSName": "${ingressNLBAddress}",
+                                            "EvaluateTargetHealth": false
+                                        }
+                                    }
+                                }]
+                            }
+                            """
+                            writeFile file: 'jx_r53_alias.json', text: r53WildcardRecordJSON
+                            sh "cat jx_r53_alias.json"
+
+                            println "Creating/updating Route53 entry"
+                            sh "aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://jx_r53_alias.json"
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Remove K8s Ingress controller') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    withProxyEnv() {
+                        sh 'helm delete  jxing'
+                    }
+                }
+            }
+        }
+    }
+}
+
+void withProxyEnv(List envVars = [], def body) {
+    List proxies = []
+    List envVaraibles = ['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']
+    withAWSParameterStore(credentialsId: '', namePrefixes: '', naming: 'relative', path: "/$PRODUCT_DOMAIN_NAME/$ENVIRONMENT_TYPE", recursive: true, regionName: "$AWS_REGION") {
+        script {
+            if (env.PROXY_HTTP) {
+                proxies << "http_proxy=$PROXY_HTTP"
+            }
+            if (env.PROXY_HTTPS) {
+                proxies << "https_proxy=$PROXY_HTTPS"
+            }
+            if (env.PROXY_NO) {
+                proxies << "no_proxy=$PROXY_NO"
+            }
+            envVaraibles.addAll(proxies)
+        }
+    }
+    envVaraibles.addAll(envVars)
+    withEnv(envVaraibles) {
+        body.call()
+    }
+}

--- a/operations/ingress/destroy/Jenkinsfile
+++ b/operations/ingress/destroy/Jenkinsfile
@@ -18,6 +18,17 @@ pipeline {
                 git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
             }
         }
+
+        stage('Switch kubectl context to ops') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    script {
+                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                }
+            }
+        }
+
         stage('Remove wildcard DNS record') {
             steps {
                 dir("operations/$AWS_REGION/env") {

--- a/operations/ingress/destroy/Jenkinsfile
+++ b/operations/ingress/destroy/Jenkinsfile
@@ -5,6 +5,12 @@ import groovy.json.JsonOutput
 pipeline {
 
     agent any
+
+    parameters {
+        choice(name: 'K8S_FLAVOR', choices: ["eks", "kops"],
+               description: 'Choose type of Kubernetes cluster (required for kops)')
+    }
+
     stages {
         stage('Git local config') {
             steps {
@@ -19,11 +25,24 @@ pipeline {
             }
         }
 
+        stage('Get K8s cluster flavor') {
+            steps {
+                script {
+                    if (env.K8S_FLAVOR == "eks") {
+                      K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
+                    } else {
+                      K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                    println K8S_CLUSTER_NAME
+                }
+            }
+        }
+
         stage('Switch kubectl context to ops') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     script {
-                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
                 }
             }
@@ -31,7 +50,7 @@ pipeline {
 
         stage('Remove wildcard DNS record') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             def parameters = readYaml file: 'jenkins/parameters.yaml'
@@ -78,7 +97,7 @@ pipeline {
 
         stage('Remove K8s Ingress controller') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         sh 'helm delete  opsing'
                     }

--- a/operations/ingress/destroy/Jenkinsfile
+++ b/operations/ingress/destroy/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                             r53WildcardRecordName = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
 
                             println "Getting ingress NLB information"
-                            ingressNLBAddress = sh(script: "kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'",
+                            ingressNLBAddress = sh(script: "kubectl get service -n kube-system opsing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'",
                                                    returnStdout: true).trim()
                             ingressNLBHostedZoneID = sh(script: "aws --region \$AWS_REGION elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text",
                                                    returnStdout: true).trim()
@@ -54,11 +54,11 @@ pipeline {
                                 }]
                             }
                             """
-                            writeFile file: 'jx_r53_alias.json', text: r53WildcardRecordJSON
-                            sh "cat jx_r53_alias.json"
+                            writeFile file: 'opsing_r53_alias.json', text: r53WildcardRecordJSON
+                            sh "cat opsing_r53_alias.json"
 
                             println "Creating/updating Route53 entry"
-                            sh "aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://jx_r53_alias.json"
+                            sh "aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://opsing_r53_alias.json"
                         }
                     }
                 }
@@ -69,7 +69,7 @@ pipeline {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
-                        sh 'helm delete  jxing'
+                        sh 'helm delete  opsing'
                     }
                 }
             }

--- a/operations/ingress/install/Jenkinsfile
+++ b/operations/ingress/install/Jenkinsfile
@@ -32,6 +32,16 @@ pipeline {
             }
         }
 
+        stage('Switch kubectl context to ops') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    script {
+                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                }
+            }
+        }
+
         stage('Deploy K8s Ingress controller') {
             steps {
                 dir("operations/$AWS_REGION/env") {

--- a/operations/ingress/install/Jenkinsfile
+++ b/operations/ingress/install/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
                 dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         writeFile file: 'ing-values.yaml', text: ingValue
-                        sh 'helm install --replace --wait --name opsing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml"
+                        sh 'helm install --replace --wait --name opsing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml'
                     }
                 }
             }

--- a/operations/ingress/install/Jenkinsfile
+++ b/operations/ingress/install/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
                         writeFile file: 'ing-values.yaml', text: ingValue
-                        sh 'helm install --replace --wait --name opsing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml || true'
+                        sh 'helm install --replace --wait --name opsing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml"
                     }
                 }
             }

--- a/operations/ingress/install/Jenkinsfile
+++ b/operations/ingress/install/Jenkinsfile
@@ -89,6 +89,7 @@ pipeline {
                 }
             }
         }
+    }
 }
 
 void withProxyEnv(List envVars = [], def body) {

--- a/operations/ingress/install/Jenkinsfile
+++ b/operations/ingress/install/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
                         writeFile file: 'ing-values.yaml', text: ingValue
-                        sh 'helm install --replace --wait --name jxing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml||true'
+                        sh 'helm install --replace --wait --name opsing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml || true'
                     }
                 }
             }
@@ -89,6 +89,7 @@ pipeline {
                 }
             }
         }
+}
 
 void withProxyEnv(List envVars = [], def body) {
     List proxies = []

--- a/operations/ingress/install/Jenkinsfile
+++ b/operations/ingress/install/Jenkinsfile
@@ -18,6 +18,12 @@ controller:
 pipeline {
 
     agent any
+
+    parameters {
+        choice(name: 'K8S_FLAVOR', choices: ["eks", "kops"],
+               description: 'Choose type of Kubernetes cluster (required for kops)')
+    }
+
     stages {
         stage('Git local config') {
             steps {
@@ -32,11 +38,24 @@ pipeline {
             }
         }
 
+        stage('Get K8s cluster flavor') {
+            steps {
+                script {
+                    if (env.K8S_FLAVOR == "eks") {
+                      K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
+                    } else {
+                      K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                    println K8S_CLUSTER_NAME
+                }
+            }
+        }
+
         stage('Switch kubectl context to ops') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     script {
-                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
                 }
             }
@@ -44,7 +63,7 @@ pipeline {
 
         stage('Deploy K8s Ingress controller') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         writeFile file: 'ing-values.yaml', text: ingValue
                         sh 'helm install --replace --wait --name opsing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml"
@@ -55,7 +74,7 @@ pipeline {
 
         stage('Create wildcard DNS record') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             def parameters = readYaml file: 'jenkins/parameters.yaml'

--- a/operations/ingress/install/Jenkinsfile
+++ b/operations/ingress/install/Jenkinsfile
@@ -1,0 +1,114 @@
+#!groovy
+
+import groovy.json.JsonOutput
+
+def ingValue = '''
+rbac:
+ create: true
+
+controller:
+ service:
+   annotations:
+     service.beta.kubernetes.io/aws-load-balancer-type: nlb
+     service.beta.kubernetes.io/aws-load-balancer-internal: true
+   enableHttp: true
+   enableHttps: false
+'''
+
+pipeline {
+
+    agent any
+    stages {
+        stage('Git local config') {
+            steps {
+                sh 'git config --global --add user.name "example"'
+                sh 'git config --global --add user.email "example@example.com"'
+            }
+        }
+        stage('Git clone') {
+            steps {
+                cleanWs()
+                git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
+            }
+        }
+
+        stage('Deploy K8s Ingress controller') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    withProxyEnv() {
+                        writeFile file: 'ing-values.yaml', text: ingValue
+                        sh 'helm install --replace --wait --name jxing --namespace kube-system stable/nginx-ingress --set rbac.create=true --values ing-values.yaml||true'
+                    }
+                }
+            }
+        }
+
+        stage('Create wildcard DNS record') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    withProxyEnv() {
+                        script {
+                            def parameters = readYaml file: 'jenkins/parameters.yaml'
+
+                            println "Getting domain name"
+                            def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + parameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
+                                                   returnStdout: true).trim().replaceAll("\\.\$", "")
+                            r53WildcardRecordName = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
+
+                            println "Getting ingress NLB information"
+                            ingressNLBAddress = sh(script: "kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'",
+                                                   returnStdout: true).trim()
+                            ingressNLBHostedZoneID = sh(script: "aws --region \$AWS_REGION elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text",
+                                                   returnStdout: true).trim()
+
+                            println "Generating record for DNS update"
+                            def r53WildcardRecordJSON = """
+                            {
+                                "Comment": "Creating Alias resource record sets in Route 53",
+                                "Changes": [{
+                                    "Action": "UPSERT",
+                                    "ResourceRecordSet": {
+                                        "Name": "${r53WildcardRecordName}",
+                                        "Type": "A",
+                                        "AliasTarget": {
+                                            "HostedZoneId": "${ingressNLBHostedZoneID}",
+                                            "DNSName": "${ingressNLBAddress}",
+                                            "EvaluateTargetHealth": false
+                                        }
+                                    }
+                                }]
+                            }
+                            """
+                            writeFile file: 'jx_r53_alias.json', text: r53WildcardRecordJSON
+                            sh "cat jx_r53_alias.json"
+
+                            println "Creating/updating Route53 entry"
+                            sh "aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://jx_r53_alias.json"
+                        }
+                    }
+                }
+            }
+        }
+
+void withProxyEnv(List envVars = [], def body) {
+    List proxies = []
+    List envVaraibles = ['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']
+    withAWSParameterStore(credentialsId: '', namePrefixes: '', naming: 'relative', path: "/$PRODUCT_DOMAIN_NAME/$ENVIRONMENT_TYPE", recursive: true, regionName: "$AWS_REGION") {
+        script {
+            if (env.PROXY_HTTP) {
+                proxies << "http_proxy=$PROXY_HTTP"
+            }
+            if (env.PROXY_HTTPS) {
+                proxies << "https_proxy=$PROXY_HTTPS"
+            }
+            if (env.PROXY_NO) {
+                proxies << "no_proxy=$PROXY_NO"
+            }
+            envVaraibles.addAll(proxies)
+        }
+    }
+    envVaraibles.addAll(envVars)
+    withEnv(envVaraibles) {
+        body.call()
+    }
+}

--- a/operations/ingress/install/Jenkinsfile
+++ b/operations/ingress/install/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
                             r53WildcardRecordName = "*." + parameters.jxDomainAliasPrefix + "." + r53DomainName
 
                             println "Getting ingress NLB information"
-                            ingressNLBAddress = sh(script: "kubectl get service -n kube-system jxing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'",
+                            ingressNLBAddress = sh(script: "kubectl get service -n kube-system opsing-nginx-ingress-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'",
                                                    returnStdout: true).trim()
                             ingressNLBHostedZoneID = sh(script: "aws --region \$AWS_REGION elbv2 describe-load-balancers --query 'LoadBalancers[?DNSName==`" + ingressNLBAddress + "`].CanonicalHostedZoneId' --output text",
                                                    returnStdout: true).trim()
@@ -79,11 +79,11 @@ pipeline {
                                 }]
                             }
                             """
-                            writeFile file: 'jx_r53_alias.json', text: r53WildcardRecordJSON
-                            sh "cat jx_r53_alias.json"
+                            writeFile file: 'opsing_r53_alias.json', text: r53WildcardRecordJSON
+                            sh "cat opsing_r53_alias.json"
 
                             println "Creating/updating Route53 entry"
-                            sh "aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://jx_r53_alias.json"
+                            sh "aws route53 change-resource-record-sets --hosted-zone-id " + parameters.jxDomainHostedZoneID + " --change-batch file://opsing_r53_alias.json"
                         }
                     }
                 }

--- a/operations/prometheus/destroy/Jenkinsfile
+++ b/operations/prometheus/destroy/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
                             println "Getting domain name"
                             def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + jenkinsParameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
                                                    returnStdout: true).trim().replaceAll("\\.\$", "")
-                            grafanaEndpoint = "http://grafana." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
+                            grafanaEndpoint = "grafana." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
                             grafanaAdminPassword = grafanaParameters.defaultAdminPassword
                         }
                     }
@@ -62,7 +62,7 @@ pipeline {
                     withProxyEnv() {
                         script {
                             def prometheusDataSourceName = "Prometheus_ops"
-                            sh "curl --verbose --user admin:${grafanaAdminPassword} ${grafanaEndpoint}/api/datasources/name/${prometheusDataSourceName} -X DELETE -H 'Content-Type: application/json;charset=UTF-8'"
+                            sh "curl --verbose --user admin:${grafanaAdminPassword} http://${grafanaEndpoint}/api/datasources/name/${prometheusDataSourceName} -X DELETE -H 'Content-Type: application/json;charset=UTF-8'"
                         }
                     }
                 }

--- a/operations/prometheus/destroy/Jenkinsfile
+++ b/operations/prometheus/destroy/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
 void withProxyEnv(List envVars = [], def body) {
     List proxies = []
     List envVaraibles = ['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']
-    withAWSParameterStore(credentialsId: '', namePrefixes: '', naming: 'absolute', path: '/proxy', recursive: true, regionName: "$AWS_REGION") {
+    withAWSParameterStore(credentialsId: '', namePrefixes: '', naming: 'relative', path: "/$PRODUCT_DOMAIN_NAME/$ENVIRONMENT_TYPE", recursive: true, regionName: "$AWS_REGION") {
         script {
             if (env.PROXY_HTTP) {
                 proxies << "http_proxy=$PROXY_HTTP"

--- a/operations/prometheus/destroy/Jenkinsfile
+++ b/operations/prometheus/destroy/Jenkinsfile
@@ -16,15 +16,23 @@ pipeline {
                 git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
             }
         }
-        stage('Destroy Prometheus') {
+
+        stage('Switch kubectl context to ops') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    script {
+                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                }
+            }
+        }
+
+        stage('Destroy Prometheus/operations') {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
                         script {
-                            sh '''#!/bin/bash -x
-                            jx delete addon prometheus
-                            kubectl -n jx delete secret prometheus-ingress
-                            '''
+                            sh 'helm delete --purge prometheus_ops'
                         }
                     }
                 }
@@ -41,7 +49,7 @@ pipeline {
                             println "Getting domain name"
                             def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + jenkinsParameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
                                                    returnStdout: true).trim().replaceAll("\\.\$", "")
-                            grafanaEndpoint = "http://grafana.jx." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
+                            grafanaEndpoint = "http://grafana." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
                             grafanaAdminPassword = grafanaParameters.defaultAdminPassword
                         }
                     }

--- a/operations/prometheus/destroy/Jenkinsfile
+++ b/operations/prometheus/destroy/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
                         script {
-                            sh 'helm delete --purge prometheus_ops'
+                            sh 'helm delete --purge prometheus-ops'
                         }
                     }
                 }

--- a/operations/prometheus/destroy/Jenkinsfile
+++ b/operations/prometheus/destroy/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
 
         stage('Switch kubectl context to ops') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     script {
                       sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }

--- a/operations/prometheus/destroy/Jenkinsfile
+++ b/operations/prometheus/destroy/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
 
         stage('Destroy Prometheus/operations') {
             steps {
-                dir("operations/$AWS_REGION/env-$env.K8S_CLUSTER_NAME") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             sh 'helm delete --purge prometheus-ops'
@@ -59,7 +59,7 @@ pipeline {
         }
         stage('Read Grafana endpoint') {
             steps {
-                dir("operations/$AWS_REGION/env-$env.K8S_CLUSTER_NAME") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             def jenkinsParameters = readYaml file: 'jenkins/parameters.yaml'
@@ -77,7 +77,7 @@ pipeline {
         }
         stage('Destroy Prometheus_ops endpoint in Grafana') {
             steps {
-                dir("operations/$AWS_REGION/env-$env.K8S_CLUSTER_NAME") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             def prometheusDataSourceName = "Prometheus_ops"

--- a/operations/prometheus/destroy/Jenkinsfile
+++ b/operations/prometheus/destroy/Jenkinsfile
@@ -3,6 +3,12 @@
 pipeline {
 
     agent any
+
+    parameters {
+        choice(name: 'K8S_FLAVOR', choices: ["eks", "kops"],
+               description: 'Choose type of Kubernetes cluster (required for kops)')
+    }
+
     stages {
         stage('Git local config') {
             steps {
@@ -17,11 +23,24 @@ pipeline {
             }
         }
 
+        stage('Get K8s cluster flavor') {
+            steps {
+                script {
+                    if (env.K8S_FLAVOR == "eks") {
+                      K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
+                    } else {
+                      K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                    println K8S_CLUSTER_NAME
+                }
+            }
+        }
+
         stage('Switch kubectl context to ops') {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     script {
-                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
                 }
             }
@@ -29,7 +48,7 @@ pipeline {
 
         stage('Destroy Prometheus/operations') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$env.K8S_CLUSTER_NAME") {
                     withProxyEnv() {
                         script {
                             sh 'helm delete --purge prometheus-ops'
@@ -40,7 +59,7 @@ pipeline {
         }
         stage('Read Grafana endpoint') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$env.K8S_CLUSTER_NAME") {
                     withProxyEnv() {
                         script {
                             def jenkinsParameters = readYaml file: 'jenkins/parameters.yaml'
@@ -58,7 +77,7 @@ pipeline {
         }
         stage('Destroy Prometheus_ops endpoint in Grafana') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$env.K8S_CLUSTER_NAME") {
                     withProxyEnv() {
                         script {
                             def prometheusDataSourceName = "Prometheus_ops"

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                     } else {
                       def K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
                     }
-                    println $K8S_CLUSTER_NAME
+                    println K8S_CLUSTER_NAME
                 }
             }
         }

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -5,10 +5,8 @@ pipeline {
     agent any
 
     parameters {
-        choice(name: 'K8S_CLUSTER_NAME', 
-               choices: ["arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops", 
-                         "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"],
-               description: 'Choose target cluster name (required for kops)')
+        choice(name: 'K8S_FLAVOR', choices: ["eks", "kops"],
+               description: 'Choose type of Kubernetes cluster (required for kops)')
     }
 
     stages {
@@ -25,11 +23,22 @@ pipeline {
             }
         }
 
+        stage('Get K8s cluster flavor') {
+            steps {
+                if (env.K8S_FLAVOR == "eks") {
+                  def K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
+                } else {
+                  def K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                }
+                println $K8S_CLUSTER_NAME
+            }
+        }
+
         stage('Switch kubectl context to ops') {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     script {
-                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME
                     }
                 }
             }

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
                             sh """
                             #!/bin/bash
                             helm install --replace --wait --name prometheus-ops --namespace lma stable/prometheus \
-                            --set=ingress.enabled=true,ingress.hosts={$prometheusEndpoint}
+                            --set=server.ingress.enabled=true,server.ingress.hosts={$prometheusEndpoint}
                             """
                         }
                     }

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -16,18 +16,18 @@ pipeline {
                 git credentialsId: 'bitbucket-key', url: '$CONFIG_REPO_URL'
             }
         }
-        stage('Deploy Prometheus/operations') {
+
+        stage('Switch kubectl context to ops') {
             steps {
                 dir("operations/$AWS_REGION/env") {
-                    withProxyEnv() {
-                        script {
-                            sh "jx create addon prometheus"
-                        }
+                    script {
+                      sh "kubectl config use-context $AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
                     }
                 }
             }
         }
-        stage('Read DNS domain') {
+
+       stage('Read DNS domain') {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {
@@ -37,14 +37,31 @@ pipeline {
                             println "Getting domain name"
                             def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + jenkinsParameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
                                                    returnStdout: true).trim().replaceAll("\\.\$", "")
-                            prometheusEndpoint = "http://prometheus.jx." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
-                            grafanaEndpoint = "http://grafana.jx." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
+                            prometheusEndpoint = "http://prometheus." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
+                            grafanaEndpoint = "http://grafana." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
                         }
                     }
                 }
             }
         }
-        stage('Add Prometheus data-source to Grafana') {
+
+        stage('Deploy Prometheus/operations') {
+            steps {
+                dir("operations/$AWS_REGION/env") {
+                    withProxyEnv() {
+                        script {
+                            sh """
+                            #!/bin/bash
+                            helm install --replace --wait --name prometheus_ops --namespace kube-system stable/prometheus \
+                            --set=ingress.enabled=true,ingress.hosts={$prometheusEndpoint}
+                            """
+                        }
+                    }
+                }
+            }
+        }
+ 
+        stage('Add Prometheus/operations data-source to Grafana') {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     withProxyEnv() {

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -3,6 +3,15 @@
 pipeline {
 
     agent any
+
+    parameters {
+        choice(name: 'K8S_CLUSTER_NAME', 
+               arn:aws:eks:eu-west-1:111860764813:cluster/
+               choices: ["arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops", 
+                         "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"],
+               description: 'Choose target cluster name (required for kops)')
+    }
+
     stages {
         stage('Git local config') {
             steps {

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
             steps {
                 dir("operations/$AWS_REGION/env") {
                     script {
-                      sh "kubectl config use-context $K8S_CLUSTER_NAME
+                      sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
                 }
             }

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
 
         stage('Switch kubectl context to ops') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     script {
                       sh "kubectl config use-context $K8S_CLUSTER_NAME"
                     }
@@ -48,7 +48,7 @@ pipeline {
 
        stage('Read DNS domain') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             def jenkinsParameters = readYaml file: 'jenkins/parameters.yaml'
@@ -66,7 +66,7 @@ pipeline {
 
         stage('Deploy Prometheus/operations') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             sh """
@@ -82,7 +82,7 @@ pipeline {
  
         stage('Add Prometheus/operations data-source to Grafana') {
             steps {
-                dir("operations/$AWS_REGION/env") {
+                dir("operations/$AWS_REGION/env-$K8S_FLAVOR") {
                     withProxyEnv() {
                         script {
                             def grafanaParameters = readYaml file: 'grafana/parameters.yaml'

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -6,7 +6,6 @@ pipeline {
 
     parameters {
         choice(name: 'K8S_CLUSTER_NAME', 
-               arn:aws:eks:eu-west-1:111860764813:cluster/
                choices: ["arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops", 
                          "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"],
                description: 'Choose target cluster name (required for kops)')

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -25,12 +25,14 @@ pipeline {
 
         stage('Get K8s cluster flavor') {
             steps {
-                if (env.K8S_FLAVOR == "eks") {
-                  def K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
-                } else {
-                  def K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                script {
+                    if (env.K8S_FLAVOR == "eks") {
+                      def K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
+                    } else {
+                      def K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                    }
+                    println $K8S_CLUSTER_NAME
                 }
-                println $K8S_CLUSTER_NAME
             }
         }
 

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
 void withProxyEnv(List envVars = [], def body) {
     List proxies = []
     List envVaraibles = ['GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no']
-    withAWSParameterStore(credentialsId: '', namePrefixes: '', naming: 'absolute', path: '/proxy', recursive: true, regionName: "$AWS_REGION") {
+    withAWSParameterStore(credentialsId: '', namePrefixes: '', naming: 'relative', path: "/$PRODUCT_DOMAIN_NAME/$ENVIRONMENT_TYPE", recursive: true, regionName: "$AWS_REGION") {
         script {
             if (env.PROXY_HTTP) {
                 proxies << "http_proxy=$PROXY_HTTP"

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -27,9 +27,9 @@ pipeline {
             steps {
                 script {
                     if (env.K8S_FLAVOR == "eks") {
-                      def K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
+                      K8S_CLUSTER_NAME = "arn:aws:eks:$AWS_REGION:$AWS_OPERATIONS_ACCOUNT_NUMBER:cluster/$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops"
                     } else {
-                      def K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
+                      K8S_CLUSTER_NAME = "$AWS_REGION-$PRODUCT_DOMAIN_NAME-$ENVIRONMENT_TYPE-ops.k8s.local"
                     }
                     println K8S_CLUSTER_NAME
                 }

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -56,8 +56,8 @@ pipeline {
                             println "Getting domain name"
                             def r53DomainName = sh(script: "aws route53 get-hosted-zone --id " + jenkinsParameters.jxDomainHostedZoneID + " --output text --query 'HostedZone.Name'", 
                                                    returnStdout: true).trim().replaceAll("\\.\$", "")
-                            prometheusEndpoint = "http://prometheus." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
-                            grafanaEndpoint = "http://grafana." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
+                            prometheusEndpoint = "prometheus." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
+                            grafanaEndpoint = "grafana." + jenkinsParameters.jxDomainAliasPrefix + "." + r53DomainName
                         }
                     }
                 }
@@ -71,7 +71,7 @@ pipeline {
                         script {
                             sh """
                             #!/bin/bash
-                            helm install --replace --wait --name prometheus-ops --namespace kube-system stable/prometheus \
+                            helm install --replace --wait --name prometheus-ops --namespace lma stable/prometheus \
                             --set=ingress.enabled=true,ingress.hosts={$prometheusEndpoint}
                             """
                         }
@@ -92,14 +92,14 @@ pipeline {
                               "name": "Prometheus_ops",
                               "isDefault": false,
                               "type": "prometheus",
-                              "url": "${prometheusEndpoint}",
+                              "url": "http://${prometheusEndpoint}",
                               "access": "proxy",
                               "basicAuth": true,
                               "basicAuthUser": "admin",
                               "basicAuthPassword": "admin"
                             }
                             """
-                            sh "curl --verbose --user admin:${grafanaAdminPassword} ${grafanaEndpoint}/api/datasources -X POST -H 'Content-Type: application/json;charset=UTF-8' --data-binary '${requestJson}'"
+                            sh "curl --verbose --user admin:${grafanaAdminPassword} http://${grafanaEndpoint}/api/datasources -X POST -H 'Content-Type: application/json;charset=UTF-8' --data-binary '${requestJson}'"
                         }
                     }
                 }

--- a/operations/prometheus/install/Jenkinsfile
+++ b/operations/prometheus/install/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                         script {
                             sh """
                             #!/bin/bash
-                            helm install --replace --wait --name prometheus_ops --namespace kube-system stable/prometheus \
+                            helm install --replace --wait --name prometheus-ops --namespace kube-system stable/prometheus \
                             --set=ingress.enabled=true,ingress.hosts={$prometheusEndpoint}
                             """
                         }


### PR DESCRIPTION
This PR reimplements and extends pipelines previously using jx to standard helm.
It includes: Ingress, Grafana and Prometheus on ops account and prometheus on app account.
It supports both eks (default) and kops via parametrized builds (user can choose Kubernetes flavor from drop-down menu).

Limitations:
* Prometheus on app account is not utilizing ingress - this can be added after deciding how to handle domain in this account. Currently prometheus is published using internal NLB
* Grafana data-source for prometheus on app account is not added automatically for similar reasons, can be added using ops account as a starting point
* more tests for EKS and for app account is recommended
* job definitions should be added to: https://github.com/kentrikos/terraform-aws-bootstrap-jenkins/blob/master/jenkins/jenkins.yaml.tpl after other work-in-progress is completed there
* jobs in this PR are using R53 domain configured via 'jxDomainHostedZoneID' and 'jxDomainAliasPrefix' in https://github.com/kentrikos/template-environment-configuration/blob/master/operations/eu-central-1/env/jenkins/parameters.yaml - this could be renamed to something more meaningful